### PR TITLE
feat: add proof CBOR decoding

### DIFF
--- a/proof.go
+++ b/proof.go
@@ -326,6 +326,9 @@ type ProofStepNeighbor struct {
 func toInt(value any) (int, error) {
 	switch v := value.(type) {
 	case int:
+		if v < 0 {
+			return 0, fmt.Errorf("negative value: %d", v)
+		}
 		return v, nil
 	case uint:
 		if uint64(v) > uint64(math.MaxInt) {

--- a/proof.go
+++ b/proof.go
@@ -17,6 +17,7 @@ package mpf
 import (
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -124,11 +125,141 @@ func (p *Proof) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(&tmpData)
 }
 
+func (p *Proof) UnmarshalCBOR(data []byte) error {
+	var tmpSteps []cbor.RawMessage
+	if _, err := cbor.Decode(data, &tmpSteps); err != nil {
+		return err
+	}
+	p.steps = p.steps[:0]
+	for idx, stepData := range tmpSteps {
+		var tmpStep ProofStep
+		if err := tmpStep.UnmarshalCBOR(stepData); err != nil {
+			return fmt.Errorf("failed to decode proof step %d: %w", idx, err)
+		}
+		p.steps = append(p.steps, tmpStep)
+	}
+	return nil
+}
+
 type ProofStep struct {
 	stepType     ProofStepType
 	prefixLength int
 	neighbors    []Hash
 	neighbor     ProofStepNeighbor
+}
+
+func (s *ProofStep) UnmarshalCBOR(data []byte) error {
+	*s = ProofStep{}
+	var tmpConstructor cbor.Constructor
+	if _, err := cbor.Decode(data, &tmpConstructor); err != nil {
+		return err
+	}
+	fields := tmpConstructor.Fields()
+	switch tmpConstructor.Constructor() {
+	case 0:
+		if len(fields) != 2 {
+			return errors.New("branch proof step missing fields")
+		}
+		prefixLen, err := toInt(fields[0])
+		if err != nil {
+			return fmt.Errorf("invalid branch prefix length: %w", err)
+		}
+		neighborsBytes, err := bytesFromField(fields[1])
+		if err != nil {
+			return fmt.Errorf("invalid branch neighbors type: %w", err)
+		}
+		if len(neighborsBytes)%HashSize != 0 {
+			return fmt.Errorf("branch neighbor data incorrect length: %d", len(neighborsBytes))
+		}
+		neighbors := make([]Hash, 0, len(neighborsBytes)/HashSize)
+		for i := 0; i < len(neighborsBytes); i += HashSize {
+			neighborHash, err := hashFromBytes(neighborsBytes[i : i+HashSize])
+			if err != nil {
+				return err
+			}
+			neighbors = append(neighbors, neighborHash)
+		}
+		s.stepType = ProofStepTypeBranch
+		s.prefixLength = prefixLen
+		s.neighbors = neighbors
+	case 1:
+		if len(fields) != 2 {
+			return errors.New("fork proof step missing fields")
+		}
+		prefixLen, err := toInt(fields[0])
+		if err != nil {
+			return fmt.Errorf("invalid fork prefix length: %w", err)
+		}
+		neighborConstructor, ok := fields[1].(cbor.Constructor)
+		if !ok {
+			return fmt.Errorf("invalid fork neighbor type: %T", fields[1])
+		}
+		if neighborConstructor.Constructor() != 0 {
+			return fmt.Errorf("unexpected fork neighbor constructor: %d", neighborConstructor.Constructor())
+		}
+		neighborFields := neighborConstructor.Fields()
+		if len(neighborFields) != 3 {
+			return errors.New("fork neighbor missing fields")
+		}
+		neighborIdx, err := toInt(neighborFields[0])
+		if err != nil {
+			return fmt.Errorf("invalid fork neighbor index: %w", err)
+		}
+		prefixBytes, err := bytesFromField(neighborFields[1])
+		if err != nil {
+			return fmt.Errorf("invalid fork neighbor prefix: %w", err)
+		}
+		rootBytes, err := bytesFromField(neighborFields[2])
+		if err != nil {
+			return fmt.Errorf("invalid fork neighbor root: %w", err)
+		}
+		neighborRoot, err := hashFromBytes(rootBytes)
+		if err != nil {
+			return fmt.Errorf("invalid fork neighbor root: %w", err)
+		}
+		if neighborIdx < 0 || neighborIdx > 0xf {
+			return fmt.Errorf("fork neighbor index out of range: %d", neighborIdx)
+		}
+		s.stepType = ProofStepTypeFork
+		s.prefixLength = prefixLen
+		s.neighbor = ProofStepNeighbor{
+			prefix: bytesToNibbles(prefixBytes),
+			nibble: Nibble(neighborIdx),
+			root:   neighborRoot,
+		}
+	case 2:
+		if len(fields) != 3 {
+			return errors.New("leaf proof step missing fields")
+		}
+		prefixLen, err := toInt(fields[0])
+		if err != nil {
+			return fmt.Errorf("invalid leaf prefix length: %w", err)
+		}
+		keyBytes, err := bytesFromField(fields[1])
+		if err != nil {
+			return fmt.Errorf("invalid leaf key: %w", err)
+		}
+		if len(keyBytes)%2 != 0 {
+			return fmt.Errorf("leaf key has odd length: %d", len(keyBytes))
+		}
+		valueBytes, err := bytesFromField(fields[2])
+		if err != nil {
+			return fmt.Errorf("invalid leaf value: %w", err)
+		}
+		leafValue, err := hashFromBytes(valueBytes)
+		if err != nil {
+			return fmt.Errorf("invalid leaf value: %w", err)
+		}
+		s.stepType = ProofStepTypeLeaf
+		s.prefixLength = prefixLen
+		s.neighbor = ProofStepNeighbor{
+			key:   bytesToNibbles(keyBytes),
+			value: leafValue,
+		}
+	default:
+		return fmt.Errorf("unknown proof step constructor: %d", tmpConstructor.Constructor())
+	}
+	return nil
 }
 
 func (s *ProofStep) MarshalCBOR() ([]byte, error) {
@@ -190,6 +321,54 @@ type ProofStepNeighbor struct {
 	prefix []Nibble
 	nibble Nibble
 	root   Hash
+}
+
+func toInt(value any) (int, error) {
+	switch v := value.(type) {
+	case int:
+		return v, nil
+	case uint:
+		if uint64(v) > uint64(math.MaxInt) {
+			return 0, fmt.Errorf("value out of range: %d", v)
+		}
+		// #nosec G115 -- conversion is safe due to explicit range check above
+		return int(int64(v)), nil
+	case int64:
+		if v < 0 {
+			return 0, fmt.Errorf("negative value: %d", v)
+		}
+		if v > int64(math.MaxInt) {
+			return 0, fmt.Errorf("value out of range: %d", v)
+		}
+		return int(v), nil
+	case uint64:
+		if v > uint64(math.MaxInt) {
+			return 0, fmt.Errorf("value out of range: %d", v)
+		}
+		return int(v), nil
+	default:
+		return 0, fmt.Errorf("unexpected numeric type: %T", value)
+	}
+}
+
+func hashFromBytes(data []byte) (Hash, error) {
+	if len(data) != HashSize {
+		return Hash{}, fmt.Errorf("expected %d bytes for hash, got %d", HashSize, len(data))
+	}
+	var ret Hash
+	copy(ret[:], data)
+	return ret, nil
+}
+
+func bytesFromField(value any) ([]byte, error) {
+	switch v := value.(type) {
+	case []byte:
+		return v, nil
+	case cbor.ByteString:
+		return v.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("unexpected bytestring type: %T", value)
+	}
 }
 
 func merkleProof(nodes []Node, myIdx int) []Hash {

--- a/proof_test.go
+++ b/proof_test.go
@@ -15,7 +15,9 @@
 package mpf
 
 import (
+	"bytes"
 	"encoding/hex"
+	"slices"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -82,6 +84,76 @@ func TestProofMarshalCbor(t *testing.T) {
 				testDef.expectedCborHex,
 			)
 		}
+
+		var decoded Proof
+		if _, err := cbor.Decode(proofCbor, &decoded); err != nil {
+			t.Fatalf("got unexpected error when decoding proof CBOR: %s", err)
+		}
+
+		roundTripBytes, err := decoded.MarshalCBOR()
+		if err != nil {
+			t.Fatalf("got unexpected error when re-marshaling proof: %s", err)
+		}
+
+		if !bytes.Equal(roundTripBytes, proofCbor) {
+			t.Fatalf("round-trip proof CBOR mismatch")
+		}
+
+		assertProofStepsEqual(t, &decoded, proof)
+	}
+}
+
+func TestProofUnmarshalForkNeighborOddPrefixBytes(t *testing.T) {
+	oddPrefix := []Nibble{0x0, 0x1, 0x0, 0x2, 0x0, 0x3}
+	neighborRoot := HashValue([]byte("neighbor"))
+
+	proof := &Proof{
+		steps: []ProofStep{
+			{
+				stepType:     ProofStepTypeFork,
+				prefixLength: len(oddPrefix),
+				neighbor: ProofStepNeighbor{
+					prefix: oddPrefix,
+					nibble: 0x4,
+					root:   neighborRoot,
+				},
+			},
+		},
+	}
+
+	encoded, err := proof.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("failed to marshal proof: %v", err)
+	}
+
+	var decoded Proof
+	if err := decoded.UnmarshalCBOR(encoded); err != nil {
+		t.Fatalf("failed to unmarshal proof: %v", err)
+	}
+
+	if len(decoded.steps) != 1 {
+		t.Fatalf("unexpected proof step count: %d", len(decoded.steps))
+	}
+
+	decodedStep := decoded.steps[0]
+	if decodedStep.stepType != ProofStepTypeFork {
+		t.Fatalf("unexpected proof step type: %v", decodedStep.stepType)
+	}
+
+	if decodedStep.prefixLength != len(oddPrefix) {
+		t.Fatalf("unexpected prefix length: %d", decodedStep.prefixLength)
+	}
+
+	if decodedStep.neighbor.nibble != 0x4 {
+		t.Fatalf("unexpected neighbor nibble: %x", decodedStep.neighbor.nibble)
+	}
+
+	if !slices.Equal(decodedStep.neighbor.prefix, oddPrefix) {
+		t.Fatalf("unexpected neighbor prefix: %v", decodedStep.neighbor.prefix)
+	}
+
+	if decodedStep.neighbor.root != neighborRoot {
+		t.Fatalf("unexpected neighbor root: %x", decodedStep.neighbor.root)
 	}
 }
 
@@ -4196,5 +4268,85 @@ func TestBigTrieProofMarshalCbor(t *testing.T) {
 			proofCborHex,
 			bigTrieProofExpectedCborHex,
 		)
+	}
+}
+
+func assertProofStepsEqual(t *testing.T, got *Proof, want *Proof) {
+	t.Helper()
+	if len(got.steps) != len(want.steps) {
+		t.Fatalf(
+			"proof step count mismatch\n  got:    %d\n  wanted: %d",
+			len(got.steps),
+			len(want.steps),
+		)
+	}
+	for idx := range want.steps {
+		gotStep := got.steps[idx]
+		wantStep := want.steps[idx]
+		if gotStep.stepType != wantStep.stepType {
+			t.Fatalf(
+				"proof step %d type mismatch\n  got:    %s\n  wanted: %s",
+				idx,
+				gotStep.stepType,
+				wantStep.stepType,
+			)
+		}
+		if gotStep.prefixLength != wantStep.prefixLength {
+			t.Fatalf(
+				"proof step %d prefix length mismatch\n  got:    %d\n  wanted: %d",
+				idx,
+				gotStep.prefixLength,
+				wantStep.prefixLength,
+			)
+		}
+		switch wantStep.stepType {
+		case ProofStepTypeBranch:
+			if len(gotStep.neighbors) != len(wantStep.neighbors) {
+				t.Fatalf(
+					"proof step %d neighbor count mismatch\n  got:    %d\n  wanted: %d",
+					idx,
+					len(gotStep.neighbors),
+					len(wantStep.neighbors),
+				)
+			}
+			for neighborIdx := range wantStep.neighbors {
+				if gotStep.neighbors[neighborIdx] != wantStep.neighbors[neighborIdx] {
+					t.Fatalf(
+						"proof step %d neighbor hash mismatch at index %d",
+						idx,
+						neighborIdx,
+					)
+				}
+			}
+		case ProofStepTypeFork:
+			if gotStep.neighbor.nibble != wantStep.neighbor.nibble {
+				t.Fatalf(
+					"proof step %d neighbor nibble mismatch\n  got:    %d\n  wanted: %d",
+					idx,
+					gotStep.neighbor.nibble,
+					wantStep.neighbor.nibble,
+				)
+			}
+			if !slices.Equal(gotStep.neighbor.prefix, wantStep.neighbor.prefix) {
+				t.Fatalf("proof step %d neighbor prefix mismatch", idx)
+			}
+			if gotStep.neighbor.root != wantStep.neighbor.root {
+				t.Fatalf(
+					"proof step %d neighbor root mismatch\n  got:    %s\n  wanted: %s",
+					idx,
+					gotStep.neighbor.root,
+					wantStep.neighbor.root,
+				)
+			}
+		case ProofStepTypeLeaf:
+			if !slices.Equal(gotStep.neighbor.key, wantStep.neighbor.key) {
+				t.Fatalf("proof step %d neighbor key mismatch", idx)
+			}
+			if gotStep.neighbor.value != wantStep.neighbor.value {
+				t.Fatalf("proof step %d neighbor value mismatch", idx)
+			}
+		default:
+			t.Fatalf("proof step %d has unknown type: %d", idx, wantStep.stepType)
+		}
 	}
 }


### PR DESCRIPTION
* feat: add proof CBOR decoding

* fix: satisfy gosec lint for uint to int conversion

* fix: accept odd-length fork neighbor prefixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decoding proofs from CBOR, enabling full serialize/deserialize workflows and validation of reconstructed proofs.
  * Improved error reporting during CBOR deserialization for clearer failure diagnostics.

* **Tests**
  * Added round-trip CBOR validation and targeted reconstruction tests to ensure correct handling of branch, fork and leaf proof cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->