### PR TITLE
feat: proof CBOR decoding

### DIFF
--- a/nibble.go
+++ b/nibble.go
@@ -16,6 +16,7 @@ package mpf
 
 import (
 	"encoding/hex"
+	"fmt"
 	"strings"
 )
 
@@ -54,6 +55,31 @@ func nibblesToBytes(data []Nibble) []byte {
 		ret = append(ret, tmpByte)
 	}
 	return ret
+}
+
+// nibblesToIndividualBytes converts each Nibble to a single byte (0x00-0x0f).
+// This is used for CBOR encoding of fork neighbor prefixes, where each nibble
+// occupies its own byte rather than being packed in pairs.
+func nibblesToIndividualBytes(data []Nibble) []byte {
+	ret := make([]byte, len(data))
+	for i, n := range data {
+		ret[i] = byte(n)
+	}
+	return ret
+}
+
+// individualBytesToNibbles converts bytes where each byte represents a single
+// nibble value (0x00-0x0f) back into a Nibble slice. Returns an error if any
+// byte exceeds the nibble range.
+func individualBytesToNibbles(data []byte) ([]Nibble, error) {
+	ret := make([]Nibble, len(data))
+	for i, b := range data {
+		if b > 0x0f {
+			return nil, fmt.Errorf("byte %d out of nibble range: 0x%02x", i, b)
+		}
+		ret[i] = Nibble(b)
+	}
+	return ret, nil
 }
 
 // nibblesToHexString converts a series of Nibbles into a hex string representing those nibbles.

--- a/proof.go
+++ b/proof.go
@@ -124,11 +124,60 @@ func (p *Proof) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(&tmpData)
 }
 
+func (p *Proof) UnmarshalCBOR(data []byte) error {
+	*p = Proof{}
+	var tmpSteps []ProofStep
+	bytesRead, err := cbor.Decode(data, &tmpSteps)
+	if err != nil {
+		return err
+	}
+	if bytesRead != len(data) {
+		return fmt.Errorf(
+			"trailing data after proof: %d bytes",
+			len(data)-bytesRead,
+		)
+	}
+	p.steps = tmpSteps
+	return nil
+}
+
 type ProofStep struct {
 	stepType     ProofStepType
 	prefixLength int
 	neighbors    []Hash
 	neighbor     ProofStepNeighbor
+}
+
+func (s *ProofStep) UnmarshalCBOR(data []byte) error {
+	*s = ProofStep{}
+	var constructor cbor.ConstructorDecoder
+	bytesRead, err := cbor.Decode(data, &constructor)
+	if err != nil {
+		return err
+	}
+	if bytesRead != len(data) {
+		return fmt.Errorf(
+			"trailing data after proof step: %d bytes",
+			len(data)-bytesRead,
+		)
+	}
+	switch constructor.Tag() {
+	case 0:
+		if err := s.unmarshalBranchStep(constructor); err != nil {
+			return fmt.Errorf("decode branch proof step: %w", err)
+		}
+	case 1:
+		if err := s.unmarshalForkStep(constructor); err != nil {
+			return fmt.Errorf("decode fork proof step: %w", err)
+		}
+	case 2:
+		if err := s.unmarshalLeafStep(constructor); err != nil {
+			return fmt.Errorf("decode leaf proof step: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown proof step constructor: %d", constructor.Tag())
+	}
+	return nil
 }
 
 func (s *ProofStep) MarshalCBOR() ([]byte, error) {
@@ -151,7 +200,7 @@ func (s *ProofStep) MarshalCBOR() ([]byte, error) {
 		return cbor.Encode(tmpData)
 
 	case ProofStepTypeFork:
-		prefixBytes := nibblesToBytes(s.neighbor.prefix)
+		prefixBytes := nibblesToIndividualBytes(s.neighbor.prefix)
 		tmpData := cbor.NewConstructorEncoder(
 			1,
 			cbor.IndefLengthList{
@@ -190,6 +239,203 @@ type ProofStepNeighbor struct {
 	prefix []Nibble
 	nibble Nibble
 	root   Hash
+}
+
+const branchProofNeighborCount = 4
+
+func (s *ProofStep) unmarshalBranchStep(
+	constructor cbor.ConstructorDecoder,
+) error {
+	var fields []cbor.RawMessage
+	if err := constructor.DecodeFields(&fields); err != nil {
+		return err
+	}
+	if len(fields) != 2 {
+		return errors.New("missing fields")
+	}
+	prefixLen, err := decodeNonNegativeInt(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid prefix length: %w", err)
+	}
+	neighborsBytes, err := decodeBytes(fields[1])
+	if err != nil {
+		return fmt.Errorf("invalid neighbors: %w", err)
+	}
+	expectedNeighborBytes := branchProofNeighborCount * HashSize
+	if len(neighborsBytes) != expectedNeighborBytes {
+		return fmt.Errorf(
+			"incorrect branch neighbor data length: got %d, want %d",
+			len(neighborsBytes),
+			expectedNeighborBytes,
+		)
+	}
+	neighbors := make([]Hash, 0, branchProofNeighborCount)
+	for i := 0; i < len(neighborsBytes); i += HashSize {
+		neighborHash, err := hashFromBytes(neighborsBytes[i : i+HashSize])
+		if err != nil {
+			return err
+		}
+		neighbors = append(neighbors, neighborHash)
+	}
+	s.stepType = ProofStepTypeBranch
+	s.prefixLength = prefixLen
+	s.neighbors = neighbors
+	return nil
+}
+
+func (s *ProofStep) unmarshalForkStep(constructor cbor.ConstructorDecoder) error {
+	var fields []cbor.RawMessage
+	if err := constructor.DecodeFields(&fields); err != nil {
+		return err
+	}
+	if len(fields) != 2 {
+		return errors.New("missing fields")
+	}
+	prefixLen, err := decodeNonNegativeInt(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid prefix length: %w", err)
+	}
+	var neighborConstructor cbor.ConstructorDecoder
+	if err := decodeExact(fields[1], &neighborConstructor); err != nil {
+		return fmt.Errorf("invalid neighbor constructor: %w", err)
+	}
+	if neighborConstructor.Tag() != 0 {
+		return fmt.Errorf(
+			"unexpected fork neighbor constructor: %d",
+			neighborConstructor.Tag(),
+		)
+	}
+	var neighborFields []cbor.RawMessage
+	if err := neighborConstructor.DecodeFields(&neighborFields); err != nil {
+		return err
+	}
+	if len(neighborFields) != 3 {
+		return errors.New("fork neighbor missing fields")
+	}
+	neighborIdx, err := decodeNonNegativeInt(neighborFields[0])
+	if err != nil {
+		return fmt.Errorf("invalid fork neighbor index: %w", err)
+	}
+	if neighborIdx > 0xf {
+		return fmt.Errorf("fork neighbor index out of range: %d", neighborIdx)
+	}
+	prefixBytes, err := decodeBytes(neighborFields[1])
+	if err != nil {
+		return fmt.Errorf("invalid fork neighbor prefix: %w", err)
+	}
+	rootBytes, err := decodeBytes(neighborFields[2])
+	if err != nil {
+		return fmt.Errorf("invalid fork neighbor root: %w", err)
+	}
+	neighborRoot, err := hashFromBytes(rootBytes)
+	if err != nil {
+		return fmt.Errorf("invalid fork neighbor root: %w", err)
+	}
+	neighborNibble, err := nibbleFromInt(neighborIdx)
+	if err != nil {
+		return fmt.Errorf("invalid fork neighbor index: %w", err)
+	}
+	s.stepType = ProofStepTypeFork
+	s.prefixLength = prefixLen
+	neighborPrefix, err := individualBytesToNibbles(prefixBytes)
+	if err != nil {
+		return fmt.Errorf("invalid fork neighbor prefix: %w", err)
+	}
+	s.neighbor = ProofStepNeighbor{
+		prefix: neighborPrefix,
+		nibble: neighborNibble,
+		root:   neighborRoot,
+	}
+	return nil
+}
+
+func (s *ProofStep) unmarshalLeafStep(constructor cbor.ConstructorDecoder) error {
+	var fields []cbor.RawMessage
+	if err := constructor.DecodeFields(&fields); err != nil {
+		return err
+	}
+	if len(fields) != 3 {
+		return errors.New("missing fields")
+	}
+	prefixLen, err := decodeNonNegativeInt(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid prefix length: %w", err)
+	}
+	keyBytes, err := decodeBytes(fields[1])
+	if err != nil {
+		return fmt.Errorf("invalid key: %w", err)
+	}
+	valueBytes, err := decodeBytes(fields[2])
+	if err != nil {
+		return fmt.Errorf("invalid value: %w", err)
+	}
+	leafValue, err := hashFromBytes(valueBytes)
+	if err != nil {
+		return fmt.Errorf("invalid value: %w", err)
+	}
+	s.stepType = ProofStepTypeLeaf
+	s.prefixLength = prefixLen
+	s.neighbor = ProofStepNeighbor{
+		key:   bytesToNibbles(keyBytes),
+		value: leafValue,
+	}
+	return nil
+}
+
+func decodeExact(data []byte, dest any) error {
+	bytesRead, err := cbor.Decode(data, dest)
+	if err != nil {
+		return err
+	}
+	if bytesRead != len(data) {
+		return fmt.Errorf("trailing field data: %d bytes", len(data)-bytesRead)
+	}
+	return nil
+}
+
+func decodeNonNegativeInt(data []byte) (int, error) {
+	var value uint64
+	if err := decodeExact(data, &value); err == nil {
+		if value > uint64(^uint(0)>>1) {
+			return 0, fmt.Errorf("value out of range: %d", value)
+		}
+		return int(value), nil
+	}
+	var signedValue int64
+	if err := decodeExact(data, &signedValue); err == nil {
+		if signedValue < 0 {
+			return 0, fmt.Errorf("negative value: %d", signedValue)
+		}
+		if uint64(signedValue) > uint64(^uint(0)>>1) {
+			return 0, fmt.Errorf("value out of range: %d", signedValue)
+		}
+		return int(signedValue), nil
+	}
+	return 0, errors.New("expected integer")
+}
+
+func decodeBytes(data []byte) ([]byte, error) {
+	var value []byte
+	if err := decodeExact(data, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func nibbleFromInt(value int) (Nibble, error) {
+	if value < 0 || value > 0xf {
+		return 0, fmt.Errorf("nibble out of range: %d", value)
+	}
+	return Nibble(uint8(value)), nil
+}
+
+func hashFromBytes(data []byte) (Hash, error) {
+	if len(data) != HashSize {
+		return Hash{}, fmt.Errorf("expected %d bytes for hash, got %d", HashSize, len(data))
+	}
+	var ret Hash
+	copy(ret[:], data)
+	return ret, nil
 }
 
 func merkleProof(nodes []Node, myIdx int) []Hash {

--- a/proof_test.go
+++ b/proof_test.go
@@ -15,7 +15,10 @@
 package mpf
 
 import (
+	"bytes"
 	"encoding/hex"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -82,6 +85,208 @@ func TestProofMarshalCbor(t *testing.T) {
 				testDef.expectedCborHex,
 			)
 		}
+
+		var decoded Proof
+		if err := decoded.UnmarshalCBOR(proofCbor); err != nil {
+			t.Fatalf("got unexpected error when decoding proof CBOR: %s", err)
+		}
+
+		roundTripBytes, err := decoded.MarshalCBOR()
+		if err != nil {
+			t.Fatalf("got unexpected error when re-marshaling proof: %s", err)
+		}
+
+		if !bytes.Equal(roundTripBytes, proofCbor) {
+			t.Fatalf("round-trip proof CBOR mismatch")
+		}
+
+		assertProofStepsEqual(t, &decoded, proof)
+	}
+}
+
+func TestProofUnmarshalForkNeighborOddPrefixBytes(t *testing.T) {
+	oddPrefix := []Nibble{0x0, 0x1, 0x0, 0x2, 0x0, 0x3}
+	neighborRoot := HashValue([]byte("neighbor"))
+
+	proof := &Proof{
+		steps: []ProofStep{
+			{
+				stepType:     ProofStepTypeFork,
+				prefixLength: len(oddPrefix),
+				neighbor: ProofStepNeighbor{
+					prefix: oddPrefix,
+					nibble: 0x4,
+					root:   neighborRoot,
+				},
+			},
+		},
+	}
+
+	encoded, err := proof.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("failed to marshal proof: %v", err)
+	}
+
+	var decoded Proof
+	if err := decoded.UnmarshalCBOR(encoded); err != nil {
+		t.Fatalf("failed to unmarshal proof: %v", err)
+	}
+
+	assertProofStepsEqual(t, &decoded, proof)
+}
+
+func TestProofForkOddNibbleCountPrefixRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name   string
+		prefix []Nibble
+	}{
+		{
+			name:   "1 nibble",
+			prefix: []Nibble{0xa},
+		},
+		{
+			name:   "3 nibbles",
+			prefix: []Nibble{0xa, 0xb, 0xc},
+		},
+		{
+			name:   "5 nibbles",
+			prefix: []Nibble{0x1, 0x2, 0x3, 0x4, 0x5},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			neighborRoot := HashValue([]byte("neighbor"))
+			proof := &Proof{
+				steps: []ProofStep{
+					{
+						stepType:     ProofStepTypeFork,
+						prefixLength: 2,
+						neighbor: ProofStepNeighbor{
+							prefix: tc.prefix,
+							nibble: 0x7,
+							root:   neighborRoot,
+						},
+					},
+				},
+			}
+
+			encoded, err := proof.MarshalCBOR()
+			if err != nil {
+				t.Fatalf("failed to marshal proof: %v", err)
+			}
+
+			var decoded Proof
+			if err := decoded.UnmarshalCBOR(encoded); err != nil {
+				t.Fatalf("failed to unmarshal proof: %v", err)
+			}
+
+			assertProofStepsEqual(t, &decoded, proof)
+		})
+	}
+}
+
+func TestProofUnmarshalRejectsTrailingBytes(t *testing.T) {
+	proof := &Proof{
+		steps: []ProofStep{
+			{
+				stepType:     ProofStepTypeLeaf,
+				prefixLength: 0,
+				neighbor: ProofStepNeighbor{
+					key:   []Nibble{0x0, 0x1},
+					value: HashValue([]byte("value")),
+				},
+			},
+		},
+	}
+	encoded, err := proof.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("failed to marshal proof: %v", err)
+	}
+	encoded = append(encoded, 0x00)
+
+	var decoded Proof
+	err = decoded.UnmarshalCBOR(encoded)
+	if err == nil {
+		t.Fatal("expected trailing byte error but got nil")
+	}
+	if !strings.Contains(err.Error(), "trailing data after proof") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProofStepUnmarshalRejectsTrailingBytes(t *testing.T) {
+	step := ProofStep{
+		stepType:     ProofStepTypeLeaf,
+		prefixLength: 0,
+		neighbor: ProofStepNeighbor{
+			key:   []Nibble{0x0, 0x1},
+			value: HashValue([]byte("value")),
+		},
+	}
+	encoded, err := step.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("failed to marshal step: %v", err)
+	}
+	encoded = append(encoded, 0x00)
+
+	var decoded ProofStep
+	err = decoded.UnmarshalCBOR(encoded)
+	if err == nil {
+		t.Fatal("expected trailing byte error but got nil")
+	}
+	if !strings.Contains(err.Error(), "trailing data after proof step") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProofUnmarshalRejectsNegativePrefixLength(t *testing.T) {
+	tmpData := cbor.IndefLengthList{
+		cbor.NewConstructorEncoder(
+			2,
+			cbor.IndefLengthList{
+				-1,
+				[]byte{0x01, 0x23},
+				HashValue([]byte("value")),
+			},
+		),
+	}
+	encoded, err := cbor.Encode(&tmpData)
+	if err != nil {
+		t.Fatalf("failed to encode malformed proof: %v", err)
+	}
+
+	var decoded Proof
+	err = decoded.UnmarshalCBOR(encoded)
+	if err == nil {
+		t.Fatal("expected negative prefix error but got nil")
+	}
+	if !strings.Contains(err.Error(), "negative value") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProofUnmarshalRejectsInvalidBranchNeighborLength(t *testing.T) {
+	tmpData := cbor.IndefLengthList{
+		cbor.NewConstructorEncoder(
+			0,
+			cbor.IndefLengthList{
+				0,
+				[]byte{0x01, 0x02, 0x03},
+			},
+		),
+	}
+	encoded, err := cbor.Encode(&tmpData)
+	if err != nil {
+		t.Fatalf("failed to encode malformed proof: %v", err)
+	}
+
+	var decoded Proof
+	err = decoded.UnmarshalCBOR(encoded)
+	if err == nil {
+		t.Fatal("expected branch neighbor length error but got nil")
+	}
+	if !strings.Contains(err.Error(), "incorrect branch neighbor data length") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -4196,5 +4401,85 @@ func TestBigTrieProofMarshalCbor(t *testing.T) {
 			proofCborHex,
 			bigTrieProofExpectedCborHex,
 		)
+	}
+}
+
+func assertProofStepsEqual(t *testing.T, got *Proof, want *Proof) {
+	t.Helper()
+	if len(got.steps) != len(want.steps) {
+		t.Fatalf(
+			"proof step count mismatch\n  got:    %d\n  wanted: %d",
+			len(got.steps),
+			len(want.steps),
+		)
+	}
+	for idx := range want.steps {
+		gotStep := got.steps[idx]
+		wantStep := want.steps[idx]
+		if gotStep.stepType != wantStep.stepType {
+			t.Fatalf(
+				"proof step %d type mismatch\n  got:    %s\n  wanted: %s",
+				idx,
+				gotStep.stepType,
+				wantStep.stepType,
+			)
+		}
+		if gotStep.prefixLength != wantStep.prefixLength {
+			t.Fatalf(
+				"proof step %d prefix length mismatch\n  got:    %d\n  wanted: %d",
+				idx,
+				gotStep.prefixLength,
+				wantStep.prefixLength,
+			)
+		}
+		switch wantStep.stepType {
+		case ProofStepTypeBranch:
+			if len(gotStep.neighbors) != len(wantStep.neighbors) {
+				t.Fatalf(
+					"proof step %d neighbor count mismatch\n  got:    %d\n  wanted: %d",
+					idx,
+					len(gotStep.neighbors),
+					len(wantStep.neighbors),
+				)
+			}
+			for neighborIdx := range wantStep.neighbors {
+				if gotStep.neighbors[neighborIdx] != wantStep.neighbors[neighborIdx] {
+					t.Fatalf(
+						"proof step %d neighbor hash mismatch at index %d",
+						idx,
+						neighborIdx,
+					)
+				}
+			}
+		case ProofStepTypeFork:
+			if gotStep.neighbor.nibble != wantStep.neighbor.nibble {
+				t.Fatalf(
+					"proof step %d neighbor nibble mismatch\n  got:    %d\n  wanted: %d",
+					idx,
+					gotStep.neighbor.nibble,
+					wantStep.neighbor.nibble,
+				)
+			}
+			if !slices.Equal(gotStep.neighbor.prefix, wantStep.neighbor.prefix) {
+				t.Fatalf("proof step %d neighbor prefix mismatch", idx)
+			}
+			if gotStep.neighbor.root != wantStep.neighbor.root {
+				t.Fatalf(
+					"proof step %d neighbor root mismatch\n  got:    %s\n  wanted: %s",
+					idx,
+					gotStep.neighbor.root,
+					wantStep.neighbor.root,
+				)
+			}
+		case ProofStepTypeLeaf:
+			if !slices.Equal(gotStep.neighbor.key, wantStep.neighbor.key) {
+				t.Fatalf("proof step %d neighbor key mismatch", idx)
+			}
+			if gotStep.neighbor.value != wantStep.neighbor.value {
+				t.Fatalf("proof step %d neighbor value mismatch", idx)
+			}
+		default:
+			t.Fatalf("proof step %d has unknown type: %d", idx, wantStep.stepType)
+		}
 	}
 }


### PR DESCRIPTION
Replaces #124 

cc @mgpai22 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CBOR decoding for `Proof` and `ProofStep` with strict validation and full round‑trip support. Handles branch, fork, and leaf steps and rejects malformed data.

- New Features
  - Added `Proof.UnmarshalCBOR` and `ProofStep.UnmarshalCBOR` (tags: 0=branch, 1=fork, 2=leaf).
  - Strict decoding/encoding: consume all bytes; non‑negative prefix lengths; fork neighbor tag=0 and index 0–15; fork prefixes encoded one byte per nibble and validated (0x00–0x0f); exactly 4 branch neighbor hashes; enforce `HashSize`.
  - Tests for round‑trip, odd nibble counts, trailing bytes (proof and step), negative values, and bad branch neighbor lengths.

<sup>Written for commit b9415398f0b93c50750af8822da96e133a773742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CBOR deserialization support for proofs, enabling decoding of proof data from CBOR format with comprehensive error handling for invalid inputs and improved validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->