### PR TITLE
chore: Pin actions to SHA hashes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 https://github.com/actions/github-script/releases/tag/v9
         id: create-release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,4 +40,4 @@ jobs:
 
       # This updates the documentation on pkg.go.dev and the latest version available via the Go module proxy
       - name: Pull new module version
-        uses: andrewslotin/go-proxy-pull-action@v1.5.0
+        uses: andrewslotin/go-proxy-pull-action@00af8a5a49c844d6dde0bbbc116b72d8fd7ae97c # v1.5.0 https://github.com/andrewslotin/go-proxy-pull-action/releases/tag/v1.5.0


### PR DESCRIPTION
1. Updated to publish.yml workflow to use SHA-pinned action references and I could not find mutable versions tags in remaining workflows.

Closes #181 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `actions/github-script` (v9) and `andrewslotin/go-proxy-pull-action` (v1.5.0) in `publish.yml` to immutable SHAs, and bump CI Go version to 1.25.x in `golangci-lint.yml` and `nilaway.yml` to keep tooling current. No other workflows use mutable tags. Closes #181.

<sup>Written for commit db2f3ef2cb03981d2c06f46cc60b1d213f2525ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/merkle-patricia-forestry/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline security and reproducibility by pinning third-party workflow dependencies to specific commit hashes, ensuring more reliable and secure automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->