### PR TITLE
chore: require Go 1.25 minimum

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/merkle-patricia-forestry
 
-go 1.24.0
+go 1.25.7
 
-toolchain go1.24.1
+toolchain go1.25.8
 
 require (
 	github.com/blinklabs-io/gouroboros v0.160.2


### PR DESCRIPTION
## Summary

Go 1.24 is end-of-life. This bumps the module to a **Go 1.25 minimum** and aligns CI with the rest of the Blink Labs Go repos (gouroboros, adder, bursa, …):

- `go.mod`: `go 1.24.0` → `go 1.25.7`, `toolchain go1.24.1` → `toolchain go1.25.8`
- `go-test.yml`: test matrix `[1.24.x, 1.25.x]` → `[1.25.x, 1.26.x]`
- `golangci-lint.yml`, `nilaway.yml`: `1.25.x` → `1.26.x`

(`publish.yml` does not set up a Go version, so it needs no change.)

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all pass locally on Go 1.26. No source changes were required; `go.sum` is unchanged.

Part of the org-wide Go 1.25 upgrade (blinklabs-io/issues#120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require Go 1.25+ and update CI to test on 1.25/1.26 and run linters on 1.26. Drops 1.24 (EOL) and aligns tooling with other Blink Labs Go repos.

- **Dependencies**
  - `go.mod`: `go 1.25.7`, `toolchain go1.25.8`
  - `go-test.yml`: matrix `[1.25.x, 1.26.x]`
  - `golangci-lint.yml`, `nilaway.yml`: use `1.26.x`

- **Migration**
  - Use Go 1.25+ locally. No source changes needed; build/test/lint pass on 1.26.

<sup>Written for commit 4a3e9c3e150c14b76e1b44c3cd7a372c84d85935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/merkle-patricia-forestry/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

