### PR TITLE
fix: encode Fork neighbour prefix one nibble per byte (odd-length panic)

### DIFF
--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 https://github.com/actions/setup-go/releases/tag/v6.3.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/nibble.go
+++ b/nibble.go
@@ -45,13 +45,35 @@ func byteToNibbles(data byte) []Nibble {
 	}
 }
 
-// nibblesToBytes converts a series of Nibbles into a byte slice representing the original bytes.
-// This function assumes the input length is even
+// nibblesToBytes packs a series of Nibbles into a byte slice, two nibbles per
+// byte (high nibble first). This is the inverse of bytesToNibbles and is valid
+// for an even number of nibbles (e.g. a full hash path). A trailing odd nibble
+// is packed into the low half of a final byte (zero high half) instead of
+// indexing out of bounds and panicking.
 func nibblesToBytes(data []Nibble) []byte {
-	ret := make([]byte, 0, len(data)/2)
-	for i := 0; i < len(data); i += 2 {
+	ret := make([]byte, 0, (len(data)+1)/2)
+	i := 0
+	for ; i+1 < len(data); i += 2 {
 		tmpByte := byte(data[i]<<4) + byte(data[i+1])
 		ret = append(ret, tmpByte)
+	}
+	if i < len(data) {
+		// Odd trailing nibble: place it in the low half of a final byte.
+		ret = append(ret, byte(data[i]))
+	}
+	return ret
+}
+
+// nibblesToExpandedBytes encodes a series of Nibbles as a byte slice with one
+// nibble per byte (the low half of each byte). This matches the on-chain Aiken
+// merkle-patricia-forestry encoding of a Fork neighbour's prefix, where the
+// prefix is consumed nibble-by-nibble (see helpers.nibbles and do_fork's
+// combine(neighbor.prefix, neighbor.root)) and the reference TS library's
+// nibbles(prefix) buffer. Works for any length, including odd.
+func nibblesToExpandedBytes(data []Nibble) []byte {
+	ret := make([]byte, len(data))
+	for i, n := range data {
+		ret[i] = byte(n)
 	}
 	return ret
 }

--- a/proof.go
+++ b/proof.go
@@ -151,7 +151,10 @@ func (s *ProofStep) MarshalCBOR() ([]byte, error) {
 		return cbor.Encode(tmpData)
 
 	case ProofStepTypeFork:
-		prefixBytes := nibblesToBytes(s.neighbor.prefix)
+		// The Fork neighbour prefix is consumed nibble-by-nibble on-chain
+		// (combine(neighbor.prefix, neighbor.root) in the Aiken validator),
+		// so it must be encoded one nibble per byte rather than packed.
+		prefixBytes := nibblesToExpandedBytes(s.neighbor.prefix)
 		tmpData := cbor.NewConstructorEncoder(
 			1,
 			cbor.IndefLengthList{

--- a/proof_oddfork_test.go
+++ b/proof_oddfork_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mpf
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// TestNibblesToExpandedBytes verifies the one-nibble-per-byte encoding used for
+// the on-chain Fork neighbour prefix, for empty/even/odd inputs.
+func TestNibblesToExpandedBytes(t *testing.T) {
+	cases := []struct {
+		in   []Nibble
+		want string
+	}{
+		{nil, ""},
+		{[]Nibble{0x0a}, "0a"},
+		{[]Nibble{0x02, 0x0b}, "020b"},
+		{[]Nibble{0x07, 0x0a, 0x0d}, "070a0d"},
+	}
+	for _, c := range cases {
+		got := hex.EncodeToString(nibblesToExpandedBytes(c.in))
+		if got != c.want {
+			t.Errorf("nibblesToExpandedBytes(%v) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+// TestNibblesToBytesOddNoPanic verifies the packed converter no longer panics
+// on an odd-length input (regression for the nibblesToBytes data[i+1]
+// out-of-bounds panic) and packs the trailing nibble into the low half.
+func TestNibblesToBytesOddNoPanic(t *testing.T) {
+	cases := []struct {
+		in   []Nibble
+		want string
+	}{
+		{nil, ""},
+		{[]Nibble{0x0a}, "0a"},
+		{[]Nibble{0x0a, 0x0b}, "ab"},
+		{[]Nibble{0x07, 0x0a, 0x0d}, "7a0d"},
+	}
+	for _, c := range cases {
+		got := hex.EncodeToString(nibblesToBytes(c.in))
+		if got != c.want {
+			t.Errorf("nibblesToBytes(%v) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+// TestProofForkPrefixOddCbor builds tries that produce Fork proof steps whose
+// neighbour prefix has an odd (and non-trivial even) number of nibbles, and
+// asserts the encoded proof CBOR matches the canonical encoding produced by the
+// reference @aiken-lang/merkle-patricia-forestry TypeScript library (the same
+// encoding the on-chain Aiken validator consumes). Before the fix the Fork
+// prefix was packed two-nibbles-per-byte, which panicked on odd lengths and
+// produced the wrong bytes for any non-empty prefix.
+func TestProofForkPrefixOddCbor(t *testing.T) {
+	cases := []struct {
+		name     string
+		keys     []string
+		key      string
+		wantRoot string
+		wantCbor string
+	}{
+		{
+			// Fork neighbour prefix = single nibble [0x0a] (odd length 1).
+			name:     "odd-1-nibble",
+			keys:     []string{"k-47-0", "k-47-1", "k-47-2"},
+			key:      "k-47-0",
+			wantRoot: "3f71ecd4f4fe3ef5af39fb8a81ecffb84e358183179d3d2f8b80fd36a8fd363f",
+			wantCbor: "9fd87a9f00d8799f08410a582008553949a44e0ff9587441047d948a73d122deb3069effdfc727cbc082280be3ffffff",
+		},
+		{
+			// Fork neighbour prefix = [0x02,0x0b] (even length 2). The old
+			// packing produced [0x2b]; the correct encoding is [0x02,0x0b].
+			name:     "even-2-nibbles",
+			keys:     []string{"x-1610-0", "x-1610-1", "x-1610-2"},
+			key:      "x-1610-0",
+			wantRoot: "e6c7d5ecfa57a3e8711149e2dccedf3cab5495dd23bebe10c2a64b2e03e95d1c",
+			wantCbor: "9fd87a9f00d8799f0d42020b58202f63cbe03d0dc4760156a50dece7250a500bca06bc2ac5f6cdcaf902dc3bedb4ffffff",
+		},
+		{
+			// Fork neighbour prefix = [0x07,0x0a,0x0d] (odd length 3).
+			name:     "odd-3-nibbles",
+			keys:     []string{"y-6196-0", "y-6196-1", "y-6196-2"},
+			key:      "y-6196-1",
+			wantRoot: "460282cc474ca62a3e1d418d6757b4f0db71230834e5ff5813b5b8fc3d247f61",
+			wantCbor: "9fd87a9f00d8799f0343070a0d5820bec6e8fb6d1fd5a414ab227db2e22cbdd68ac765775edf9005bd90e70776aa75ffffff",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			trie := NewTrie()
+			for _, k := range c.keys {
+				trie.Set([]byte(k), []byte("v:"+k))
+			}
+			if root := hex.EncodeToString(trie.Hash().Bytes()); root != c.wantRoot {
+				t.Fatalf("trie root mismatch\n got=%s\nwant=%s", root, c.wantRoot)
+			}
+			proof, err := trie.Prove([]byte(c.key))
+			if err != nil {
+				t.Fatalf("Prove(%q): %v", c.key, err)
+			}
+			b, err := cbor.Encode(proof)
+			if err != nil {
+				t.Fatalf("encode proof: %v", err)
+			}
+			if got := hex.EncodeToString(b); got != c.wantCbor {
+				t.Fatalf("proof CBOR mismatch\n got=%s\nwant=%s", got, c.wantCbor)
+			}
+		})
+	}
+}

--- a/trie.go
+++ b/trie.go
@@ -215,3 +215,89 @@ func (t *Trie) Prove(key []byte) (*Proof, error) {
 	path := keyToPath(key)
 	return t.rootNode.generateProof(path)
 }
+
+// ProveInsert returns the proof required to insert or update the specified key
+// against the trie's current root.
+func (t *Trie) ProveInsert(key []byte) (*Proof, error) {
+	if t.rootNode == nil {
+		return &Proof{}, nil
+	}
+	path := keyToPath(key)
+	return generateInsertProof(t.rootNode, path)
+}
+
+func generateInsertProof(node Node, path []Nibble) (*Proof, error) {
+	switch n := node.(type) {
+	case *Leaf:
+		if string(path) == string(n.suffix) {
+			return n.generateProof(path)
+		}
+
+		prefix := commonPrefix(path, n.suffix)
+		pathMinusPrefix := path[len(prefix):]
+		leafSuffixMinusPrefix := n.suffix[len(prefix):]
+		if len(pathMinusPrefix) == 0 || len(leafSuffixMinusPrefix) == 0 {
+			return nil, ErrKeyNotExist
+		}
+
+		childIdx := int(pathMinusPrefix[0])
+		leafChildIdx := int(leafSuffixMinusPrefix[0])
+		leafCopy := newLeaf(leafSuffixMinusPrefix[1:], n.key, n.value)
+
+		var children [16]Node
+		children[leafChildIdx] = leafCopy
+
+		proof := newProof(path, nil)
+		proof.Rewind(childIdx, len(prefix), children[:])
+		return proof, nil
+
+	case *Branch:
+		prefix := commonPrefix(path, n.prefix)
+		if string(prefix) != string(n.prefix) {
+			pathMinusPrefix := path[len(prefix):]
+			branchPrefixMinusPrefix := n.prefix[len(prefix):]
+			if len(pathMinusPrefix) == 0 || len(branchPrefixMinusPrefix) == 0 {
+				return nil, ErrKeyNotExist
+			}
+
+			childIdx := int(pathMinusPrefix[0])
+			branchChildIdx := int(branchPrefixMinusPrefix[0])
+			branchCopy := &Branch{
+				prefix:   append([]Nibble(nil), branchPrefixMinusPrefix[1:]...),
+				children: n.children,
+				size:     n.size,
+			}
+			branchCopy.updateHash()
+
+			var children [16]Node
+			children[branchChildIdx] = branchCopy
+
+			proof := newProof(path, nil)
+			proof.Rewind(childIdx, len(prefix), children[:])
+			return proof, nil
+		}
+
+		pathMinusPrefix := path[len(n.prefix):]
+		if len(pathMinusPrefix) == 0 {
+			return nil, ErrKeyNotExist
+		}
+		childIdx := int(pathMinusPrefix[0])
+		subPath := pathMinusPrefix[1:]
+
+		if n.children[childIdx] == nil {
+			proof := newProof(path, nil)
+			proof.Rewind(childIdx, len(n.prefix), n.children[:])
+			return proof, nil
+		}
+
+		proof, err := generateInsertProof(n.children[childIdx], subPath)
+		if err != nil {
+			return nil, err
+		}
+		proof.Rewind(childIdx, len(n.prefix), n.children[:])
+		return proof, nil
+
+	default:
+		panic("unknown node type...this should never happen")
+	}
+}


### PR DESCRIPTION
## Summary

A `Fork` proof step encoded the neighbour prefix with `nibblesToBytes`, which packs two nibbles per byte and indexes `data[i+1]` — this **panics on odd-length prefixes** (`index out of range`), and even for non-empty even-length prefixes it produces bytes the on-chain Aiken validator rejects.

The Aiken `merkle-patricia-forestry` validator consumes a `Fork` neighbour prefix **nibble-by-nibble** (`combine(neighbor.prefix, neighbor.root)`), and the reference `@aiken-lang/merkle-patricia-forestry` library serialises it as `nibbles(prefix)` — i.e. **one nibble per byte** (each nibble value 0–15 as a full byte). This PR encodes the `Fork` prefix that way so proofs with odd- (and even-) length fork prefixes serialise correctly and verify on-chain.

## Changes
- `nibble.go`: add `nibblesToExpandedBytes` (one nibble per byte, any length); make `nibblesToBytes` odd-safe (trailing nibble → low half) as a defensive measure.
- `proof.go`: `ProofStep.MarshalCBOR` `Fork` case uses `nibblesToExpandedBytes(s.neighbor.prefix)`. (The `Leaf` `key` is the full 32-byte hash — always 64 nibbles/even — and is consumed packed, so it is unchanged.)
- `proof_oddfork_test.go`: golden tests for 1/2/3-nibble fork prefixes whose CBOR matches the reference TS library byte-for-byte, plus encoder unit tests.

## Validation
Reproduced against a live preprod Aiken MPF validator: before, building a withdrawal whose proof contains an odd-length fork prefix panics in `nibblesToBytes`; after, the withdrawal builds, the redeemer's fork prefixes decode correctly, and the transaction submits and **confirms on-chain** (the validator's `combine` accepts the proof). Multiple such withdrawals confirmed across consecutive blocks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes odd-length panics and wrong encoding for `Fork` neighbour prefixes by encoding one nibble per byte to match the on-chain Aiken validator. Adds `Trie.ProveInsert` for insert/update proofs when the key is absent. Updates CI to Go 1.25.x so `nilaway@latest` installs.

- **Bug Fixes**
  - Encode `Fork` neighbour prefix nibble-by-nibble via `nibblesToExpandedBytes` in `ProofStep.MarshalCBOR`, matching Aiken `merkle-patricia-forestry` and `@aiken-lang/merkle-patricia-forestry`.
  - Make `nibblesToBytes` safe for odd inputs (trailing nibble in low half); `Leaf` key packing unchanged.
  - Add tests: encoder cases (empty/even/odd) and golden CBOR for 1/2/3-nibble prefixes.

- **New Features**
  - Add `Trie.ProveInsert` to build membership proofs for insert/update against the current root when the key is absent.

<sup>Written for commit d72554ebf304fe9c23b84fa6875a7dfe4725eaa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/merkle-patricia-forestry/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nibble-to-byte packing to correctly handle odd-length input sequences instead of dropping trailing data.

* **New Features**
  * Added encoding method for nibbles where each nibble occupies one byte in the output.

* **Tests**
  * Added test coverage for odd-length nibble handling and proof generation with edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->