### PR TITLE
fix: resolve nilway warnings in trie root collapse

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -147,32 +147,29 @@ func (t *Trie) Delete(key []byte) error {
 		// collapse root if it now has a single child:
 		// splice the vanished branch's prefix and the child slot nibble into that child.
 		if n.size == 1 {
-			var (
-				onlyIdx   int
-				onlyChild Node
-			)
-			for i, c := range n.children {
-				if c != nil {
-					onlyIdx, onlyChild = i, c
-					break
+			for onlyIdx, child := range n.children {
+				if child == nil {
+					continue
 				}
+				switch c := child.(type) {
+				case *Leaf:
+					// new suffix = n.prefix ++ [onlyIdx] ++ c.suffix
+					newSuffix := slices.Concat(n.prefix, []Nibble{Nibble(onlyIdx)}, c.suffix)
+					c.suffix = newSuffix
+					c.updateHash()
+					t.rootNode = c
+				case *Branch:
+					// new prefix = n.prefix ++ [onlyIdx] ++ c.prefix
+					newPrefix := slices.Concat(n.prefix, []Nibble{Nibble(onlyIdx)}, c.prefix)
+					c.prefix = newPrefix
+					c.updateHash()
+					t.rootNode = c
+				default:
+					panic("unknown node type...this should never happen")
+				}
+				return nil
 			}
-			switch c := onlyChild.(type) {
-			case *Leaf:
-				// new suffix = n.prefix ++ [onlyIdx] ++ c.suffix
-				newSuffix := slices.Concat(n.prefix, []Nibble{Nibble(onlyIdx)}, c.suffix)
-				c.suffix = newSuffix
-				c.updateHash()
-				t.rootNode = c
-			case *Branch:
-				// new prefix = n.prefix ++ [onlyIdx] ++ c.prefix
-				newPrefix := slices.Concat(n.prefix, []Nibble{Nibble(onlyIdx)}, c.prefix)
-				c.prefix = newPrefix
-				c.updateHash()
-				t.rootNode = c
-			default:
-				panic("unknown node type...this should never happen")
-			}
+			panic("branch size does not match children...this should never happen")
 		}
 	default:
 		panic("unknown node type...this should never happen")


### PR DESCRIPTION
1. Made changes to resolve potential nil dereferences detected by NilAway during trie root collapse.
2. Made changes to process the remaining child only after an explicit nil check and panic on inconsistent branch state.
3. Verified the changes with `make nilaway` and `go test -race ./...`.

Closes #185 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes potential nil dereferences in trie root collapse by handling the only non-nil child safely and enforcing branch consistency. Removes NilAway warnings and keeps root splice logic correct.

- **Bug Fixes**
  - Iterate children and process only the non-nil child when `n.size == 1`.
  - Add panic if `n.size` is 1 but no child is found to catch inconsistent branch state.
  - Preserve splice logic: update leaf suffix or branch prefix, rehash, and set `t.rootNode`.
  - Verified with `make nilaway` and `go test -race ./...`.

<sup>Written for commit fd92e786f72ea2b1229875ad7d8acb0a7da6b801. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/merkle-patricia-forestry/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deletion behavior for entries in trie-based data structures.
  - Fixed edge cases where removing an entry could leave the root structure incorrectly collapsed.
  - Added safeguards to detect inconsistent internal state during deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->